### PR TITLE
Func to create formatted parse error expr

### DIFF
--- a/src/calculator.c
+++ b/src/calculator.c
@@ -182,6 +182,13 @@ int main(int argc, char const *argv[])
 
 	Expr *parsedExpression = ParseExpression(&ts, 0, (Token){TOK_END_OF_STREAM});
 
+	if (parsedExpression && parsedExpression->type == EXPR_PARSE_ERROR)
+	{
+		ParseError err = parsedExpression->error.v;
+		fprintf(stderr, "Error parsing [location:%d:%d]: (%s)\n", err.line, err.column, err.message);
+		return 1;
+	}
+
 	if (outputOpt & OUTPUT_INFIX_PARENS)
 	{
 		printf("Interpretation (Infix): ");

--- a/src/parser.c
+++ b/src/parser.c
@@ -74,7 +74,7 @@ Expr *ParseExpression(TokenStream *ts, int minimumPrecedence, Token stopToken)
 			return ErrorExpr(
 				"Unexpected token: %d '%c'\n"
 				"At: %s\n",
-				0, 0, // TODO(jkk): line and column
+				token.line, token.column,
 				token.type, token.type,
 				ts->at);
 		}
@@ -102,7 +102,7 @@ Expr *ParseExpression(TokenStream *ts, int minimumPrecedence, Token stopToken)
 			return ErrorExpr(
 				"Unexpected token: %d '%c'\n"
 				"At: %s\n",
-				0, 0, // TODO(jkk): line and column
+				tokOp.line, tokOp.column,
 				tokOp.type, tokOp.type,
 				ts->at);
 		}

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -10,6 +10,8 @@ typedef enum TokenType_t
 typedef struct Token_t
 {
 	int type;
+	int line;
+	int column;
 	double number;
 } Token;
 
@@ -17,6 +19,8 @@ typedef struct TokenStream_t
 {
 	const char *at;
 	const char *const end;
+	const char *lineStart;
+	int lineCount;
 } TokenStream;
 
 TokenStream TokenStreamFromCStr(const char *str);

--- a/tests/test_tokenizer.c
+++ b/tests/test_tokenizer.c
@@ -67,6 +67,21 @@ void TEST_NextToken_CharactersBetween1And255_TokenTypeEqualsCharacterOrdinalValu
 	TEST_ASSERT_EQUAL_INT32('\xff', tokHexFF.type);
 }
 
+void TEST_NextToken_SeveralLinesAndColumns_ExpectedLineAndColumn(void)
+{
+	// Arrange
+	TokenStream ts = TokenStreamFromCStr("\n\n   .");
+	int expectedLine = 2;
+	int expectedColumn = 3;
+
+	// Act
+	Token token = NextToken(&ts);
+
+	// Assert
+	TEST_ASSERT_EQUAL_INT32(expectedLine, token.line);
+	TEST_ASSERT_EQUAL_INT32(expectedColumn, token.column);
+}
+
 int main(void)
 {
 	UNITY_BEGIN();
@@ -75,5 +90,6 @@ int main(void)
 	RUN_TEST(TEST_NextToken_EmptyInput_EmptyOutput);
 	RUN_TEST(TEST_NextToken_NumberInInput_MatchingNumberToken);
 	RUN_TEST(TEST_NextToken_CharactersBetween1And255_TokenTypeEqualsCharacterOrdinalValue);
+	RUN_TEST(TEST_NextToken_SeveralLinesAndColumns_ExpectedLineAndColumn);
 	return UNITY_END();
 }


### PR DESCRIPTION
Now errors are propagated up the call tree instead of being printed immediately.
This is done to create a clearer separation of responsibility and to minimize implicit dependencies.